### PR TITLE
fixes date-related stations tests - closes #22

### DIFF
--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -1,5 +1,5 @@
 class Station < ActiveRecord::Base
-  validates_presence_of :name, :dock_count, :city_id #,:installation_date
+  validates_presence_of :name, :dock_count, :city_id ,:installation_date
   belongs_to :cities
 
   def self.average_dock_count

--- a/spec/features/user_sees_station_dashboard_spec.rb
+++ b/spec/features/user_sees_station_dashboard_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "User visits '/station-dashboard'" do
   before :all do
-    Station.create(name: "Mission", dock_count: 30, city_id: 2, installation_date: 1/4/15)
-    Station.create(name: "Embarcadero", dock_count: 50, city_id: 2, installation_date: 3/4/16)
-    Station.create(name: "Rockridge", dock_count: 15, city_id: 3, installation_date: 5/4/17)
+    Station.create(name: "Mission", dock_count: 30, city_id: 2, installation_date: "1/4/15")
+    Station.create(name: "Embarcadero", dock_count: 50, city_id: 2, installation_date: "3/4/16")
+    Station.create(name: "Rockridge", dock_count: 15, city_id: 3, installation_date: "5/4/17")
     visit("/stations/station-dashboard")
   end
 
@@ -24,12 +24,10 @@ RSpec.describe "User visits '/station-dashboard'" do
   it "and sees stations where fewest bikes are available" do
     expect(page).to have_content("Stations with Least Bikes: Rockridge")
   end
-  #
-  # need to fix dates issue before these tests pass
-  # it "and sees most recently installed station" do
-  #   expect(page).to have_content("Newest Stations: Rockridge")
-  # end
-  # it "and sees oldest station" do
-  #   expect(page).to have_content("Oldest Stations: Mission")
-  # end
+  it "and sees most recently installed station" do
+    expect(page).to have_content("Newest Stations: Rockridge")
+  end
+  it "and sees oldest station" do
+    expect(page).to have_content("Oldest Stations: Mission")
+  end
 end

--- a/spec/models/station_spec.rb
+++ b/spec/models/station_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe Station do
   end
   describe "Class Methods" do
     before :each do
-      Station.create(name: "Mission", dock_count: 30, city_id: 2, installation_date: 1/4/15)
-      Station.create(name: "Embarcadero", dock_count: 50, city_id: 2, installation_date: 3/4/16)
-      Station.create(name: "Rockridge", dock_count: 15, city_id: 3, installation_date: 5/4/17)
-      Station.create(name: "Marina", dock_count: 15, city_id: 5, installation_date: 5/1/16)
+      Station.create(name: "Mission", dock_count: 30, city_id: 2, installation_date: "1/4/15")
+      Station.create(name: "Embarcadero", dock_count: 50, city_id: 2, installation_date: "3/4/16")
+      Station.create(name: "Rockridge", dock_count: 15, city_id: 3, installation_date: "5/4/17")
+      Station.create(name: "Marina", dock_count: 15, city_id: 5, installation_date: "5/1/16")
     end
 
     describe ".average_dock_count" do
@@ -57,17 +57,15 @@ RSpec.describe Station do
         expect(Station.stations_with_least_bikes).to eq(["Rockridge", "Marina"])
       end
     end
-    #
-    # need to fix dates issue before these tests pass
-    # describe ".newest_stations" do
-    #   it "returns array of newest station names" do
-    #     expect(Station.newest_stations).to eq(["Rockridge"])
-    #   end
-    # end
-    # describe ".oldest_stations" do
-    #   it "returns an array of oldest station names" do
-    #     expect(Station.oldest_stations).to eq(["Mission"])
-    #   end
-    # end
+    describe ".newest_stations" do
+      it "returns array of newest station names" do
+        expect(Station.newest_stations).to eq(["Rockridge"])
+      end
+    end
+    describe ".oldest_stations" do
+      it "returns an array of oldest station names" do
+        expect(Station.oldest_stations).to eq(["Mission"])
+      end
+    end
   end
 end


### PR DESCRIPTION
fixes/uncomments date-related tests and uncomments installation_date in Station validates_presence_of line

all station model tests and station-dashboard feature tests passing